### PR TITLE
Adding support for SELECT count(foobar) where foobar may be anything. Be...

### DIFF
--- a/raidenjpa-core/src/main/java/org/raidenjpa/query/parser/SelectElement.java
+++ b/raidenjpa-core/src/main/java/org/raidenjpa/query/parser/SelectElement.java
@@ -16,7 +16,7 @@ public class SelectElement {
 	
 	@BadSmell("path, primite obsession")
 	public SelectElement(String element) {
-		if (element.toUpperCase().equals("COUNT(*)")) {
+		if (element.toUpperCase().startsWith("COUNT(")) {
 			count = true;
 		} else if (element.toUpperCase().startsWith("MAX(")) {
 			max = true;

--- a/raidenjpa-core/src/test/java/org/raidenjpa/query/join/GroupByTest.java
+++ b/raidenjpa-core/src/test/java/org/raidenjpa/query/join/GroupByTest.java
@@ -31,6 +31,24 @@ public class GroupByTest extends AbstractTestCase {
 	}
 	
 	@Test
+	public void testCountColumnWithoutGroupBy() {
+		createABC();
+		createA("a1");
+		createA("a2");
+		
+		String jpql;
+		QueryHelper query;
+		List<?> result;
+		
+		jpql = "SELECT count(a.id) FROM A a";
+		query = new QueryHelper(jpql);
+		result = query.getResultList();
+		assertEquals(1, result.size());
+		assertEquals(3l, result.get(0));
+	}
+	
+	
+	@Test
 	public void testCountWithGroupBy() {
 		createA("a1", 1);
 		createA("a1", 0);


### PR DESCRIPTION
...havior is the same as count(*).

O OpenJPA não suporta count(*), tem de ser count(1) ou count(tabela.id), então eu modifiquei o que o Raiden fazia para deixa-lo flexível o suficiente para aceitar qualquer coisa dentro do count().
